### PR TITLE
Bug fixes vis-a-vis current Firefox

### DIFF
--- a/jquery.fileinput.js
+++ b/jquery.fileinput.js
@@ -19,11 +19,11 @@
         selector.each(function() {
             var element = $(this);
             element.wrap("<div class=\"fileinput-wrapper\" style=\"position: relative; display: inline-block;\" />");
-            element.attr("tabindex", "-1").css({"font-size": "100px", height: "100%", filter: "alpha(opacity=0)", "-moz-opacity": 0, opacity: 0, position: "absolute", right: 0, top: 0, "z-index": -1});
+            element.attr("tabindex", "-1").css({height: "100%", filter: "alpha(opacity=0)", "-moz-opacity": 0, opacity: 0, position: "absolute", right: 0, top: 0, "z-index": -1});
             element.before(replacementHtml);
             element.prev().addClass("fileinput");
             var ua = $.browser;
-            if (ua.opera || (ua.mozilla && ua.version < "2.0")) {
+            if (ua.opera || (ua.mozilla && parseFloat(ua.version) < 2.0)) {
                 element.css("z-index", "auto");
                 element.prev(".fileinput").css("z-index", -1);
                 element.removeAttr("tabindex");


### PR DESCRIPTION
The ua.version comparison needs to be a float comparison, not string. (I.e., because current FF versions like "18.0" compare as < "2.0").

I also removed the explicit "font-size: 100px" setting because, in my own tests, that broke the element substitution in Firefox. The clickable area never matched the size of the replacement element unless I removed that font-size.
