### PR TITLE
IE 8,9 support

### DIFF
--- a/jquery.fileinput.js
+++ b/jquery.fileinput.js
@@ -8,13 +8,17 @@
  */
 (function($) {
     $.support.cssPseudoClasses = (function() {
-        var input = $("<input type='checkbox' checked/>").appendTo('body');
-        var style = $('<style type="text/css" />').appendTo('head');
-        style.text("input:checked {width: 200px; display: none}");
-        var support = input.css('width') == "200px";
-        input.remove();
-        style.remove();
-        return support;
+        try {
+            var input = $("<input type='checkbox' checked/>").appendTo('body');
+            var style = $('<style type="text/css" />').appendTo('head');
+            style.text("input:checked {width: 200px; display: none}");
+            var support = input.css('width') == "200px";
+            input.remove();
+            style.remove();
+            return support;
+        } catch (e) {
+            return false;
+        }
     })();
 
     $.fn.fileinput = function(replacement) {


### PR DESCRIPTION
Hi, 

I've just tested your plugin and added a simple try/catch to support checking function. Basic functionality now works in IE 8 and 9. 

However, I think it could use a little extra code to set the file input width and height properly, so that clicking replacement element anywhere pops up the 'choose file dialog'. I intentionally don't promise looking into it :)
